### PR TITLE
Addition of `#![warn(clippy::nursery, clippy::pedantic)]`.

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,9 +1,11 @@
 #![warn(clippy::nursery, clippy::pedantic)]
 
 mod util;
+
 use tauri::{
     CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem,
 };
+
 use util::{
     convert_all_app_icons_to_png, create_preferences_if_missing, get_icon, handle_input,
     launch_on_login, open_command,
@@ -22,6 +24,7 @@ fn create_system_tray() -> SystemTray {
         .add_item(quit);
     SystemTray::new().with_menu(tray_menu)
 }
+
 fn main() {
     convert_all_app_icons_to_png();
     create_preferences_if_missing();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::nursery, clippy::pedantic)]
+
 mod util;
 use tauri::{
     CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem,
@@ -6,7 +8,6 @@ use util::{
     convert_all_app_icons_to_png, create_preferences_if_missing, get_icon, handle_input,
     launch_on_login, open_command,
 };
-use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
 fn create_system_tray() -> SystemTray {
     let quit = CustomMenuItem::new("Quit".to_string(), "Quit");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,9 @@ use tauri::{
     CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem,
 };
 
+#[allow(unused_imports)]
+use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
+
 use util::{
     convert_all_app_icons_to_png, create_preferences_if_missing, get_icon, handle_input,
     launch_on_login, open_command,

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -2,16 +2,19 @@ mod calculator;
 mod icons;
 mod preferences;
 mod search;
-use std::process::Command;
+
 extern crate directories;
-use directories::ProjectDirs;
 extern crate plist;
+
+use std::{process::Command, time::Instant};
+
+use directories::ProjectDirs;
 use auto_launch::AutoLaunchBuilder;
 use calculator::calculate;
+
 pub use icons::convert_all_app_icons_to_png;
 pub use preferences::create_preferences_if_missing;
 pub use search::{search, similarity_sort, ResultType};
-use std::time::Instant;
 
 #[tauri::command]
 pub async fn handle_input(input: String) -> (Vec<String>, f32, i32) {
@@ -59,12 +62,11 @@ pub fn get_icon(app_name: &str) -> String {
         let icon_path = icon_dir.join(app_name.to_owned() + &".png");
         if icon_path.exists() {
             return icon_path.to_str().unwrap().to_owned();
-        } else {
-            return String::from("");
         }
-    } else {
         return String::from("");
+
     }
+    return String::from("");
 }
 
 #[tauri::command]

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -6,15 +6,20 @@ mod search;
 extern crate directories;
 extern crate plist;
 
-use std::{process::Command, time::Instant};
-
-use directories::ProjectDirs;
 use auto_launch::AutoLaunchBuilder;
 use calculator::calculate;
+use directories::ProjectDirs;
+use std::{process::Command, time::Instant};
 
 pub use icons::convert_all_app_icons_to_png;
 pub use preferences::create_preferences_if_missing;
-pub use search::{search, similarity_sort, ResultType};
+pub use search::{search, similarity_sort};
+
+pub enum ResultType {
+    Applications = 1,
+    Files = 2,
+    Calculation = 3,
+}
 
 #[tauri::command]
 pub async fn handle_input(input: String) -> (Vec<String>, f32, i32) {
@@ -64,7 +69,6 @@ pub fn get_icon(app_name: &str) -> String {
             return icon_path.to_str().unwrap().to_owned();
         }
         return String::from("");
-
     }
     return String::from("");
 }

--- a/src-tauri/src/util/calculator.rs
+++ b/src-tauri/src/util/calculator.rs
@@ -1,8 +1,8 @@
 use chrono::{Local, TimeZone};
-use chrono_tz::OffsetName;
-use chrono_tz::Tz;
+use chrono_tz::{OffsetName, Tz};
+
 use num_format::SystemLocale;
-use smartcalc::*;
+use smartcalc::SmartCalc;
 
 pub fn calculate(input: &str) -> String {
     let locale = SystemLocale::default().unwrap();

--- a/src-tauri/src/util/icons.rs
+++ b/src-tauri/src/util/icons.rs
@@ -47,6 +47,7 @@ fn get_icon_path(app_path: &str) -> String {
                 let icon_path = icon_path.unwrap().as_string().unwrap();
                 return app_path.to_owned() + &"/Contents/Resources/" + icon_path + &".icns";
             }
+
             return String::from("");
         }
         Err(_) => {

--- a/src-tauri/src/util/icons.rs
+++ b/src-tauri/src/util/icons.rs
@@ -46,9 +46,8 @@ fn get_icon_path(app_path: &str) -> String {
             if icon_path.is_some() {
                 let icon_path = icon_path.unwrap().as_string().unwrap();
                 return app_path.to_owned() + &"/Contents/Resources/" + icon_path + &".icns";
-            } else {
-                return String::from("");
             }
+            return String::from("");
         }
         Err(_) => {
             return String::from("");

--- a/src-tauri/src/util/preferences.rs
+++ b/src-tauri/src/util/preferences.rs
@@ -14,6 +14,21 @@ struct Theme {
     dark_overlay: String,
 }
 
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            primary_bg_color: String::from("rgba(20, 20, 30, 0.6)"),
+            secondary_bg_color: String::from("rgba(84, 101, 115, 0.6)"),
+            primary_text_color: String::from("#FFFFFF"),
+            secondary_text_color: String::from("#878787"),
+            primary_accent_color: String::from("#556CE5"),
+            secondary_accent_color: String::from("#48A5FF"),
+            highlight_overlay: String::from("rgba(255, 255, 255, 0.1)"),
+            dark_overlay: String::from("rgba(0, 0, 0, 0.1)"),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 struct Preferences {
     shortcut: String,
@@ -35,16 +50,7 @@ pub fn create_preferences_if_missing() {
             fs::write(preferences_path, &preference_text).unwrap();
         }
         if !theme_path.exists() {
-            let theme = Theme {
-                primary_bg_color: String::from("rgba(20, 20, 30, 0.6)"),
-                secondary_bg_color: String::from("rgba(84, 101, 115, 0.6)"),
-                primary_text_color: String::from("#FFFFFF"),
-                secondary_text_color: String::from("#878787"),
-                primary_accent_color: String::from("#556CE5"),
-                secondary_accent_color: String::from("#48A5FF"),
-                highlight_overlay: String::from("rgba(255, 255, 255, 0.1)"),
-                dark_overlay: String::from("rgba(0, 0, 0, 0.1)"),
-            };
+            let theme = Theme::default();
             let theme_text = serde_json::to_string(&theme).unwrap();
             fs::write(theme_path, &theme_text).unwrap();
         }

--- a/src-tauri/src/util/search.rs
+++ b/src-tauri/src/util/search.rs
@@ -2,12 +2,6 @@ use rust_search::SearchBuilder;
 use std::path::Path;
 use strsim::jaro_winkler;
 
-pub enum ResultType {
-    Applications = 1,
-    Files = 2,
-    Calculation = 3,
-}
-
 fn file_name_from_path(path: &str) -> String {
     let path = Path::new(path);
     let file_name = path.file_name().unwrap().to_str().unwrap();


### PR DESCRIPTION
Helping out with linting, asked [here](https://github.com/ParthJadhav/rust_search/commit/2403afbf1fc117af8e90462c3e8d5b0c52882e82#commitcomment-94989279) to do this.

I cannot build this on linux, since it relies on the OS being macos. Any testing to see if this actually fully works can only be on that system.