### PR TITLE
fix: `set_timezone` issue

### DIFF
--- a/src-tauri/src/util/calculator.rs
+++ b/src-tauri/src/util/calculator.rs
@@ -10,9 +10,13 @@ pub fn calculate(input: &str) -> String {
         Some(tz) => match tz.parse::<Tz>() {
             Ok(tz) => {
                 let date_time = Local::now().date_naive();
-                tz.offset_from_utc_date(&date_time)
+                let mut offset = tz.offset_from_utc_date(&date_time)
                     .abbreviation()
-                    .to_string()
+                    .to_string();
+                if offset.starts_with('+') || offset.starts_with('-') {
+                    offset.insert_str(0, "GMT");
+                }
+                offset
             }
             Err(_) => "UTC".to_string(),
         },


### PR DESCRIPTION
Fix error when offset starts with '+' or '-':

```
thread 'tokio-runtime-worker' panicked at 'called Result::unwrap() on an Err value: "Timezone information not found"', src/util/calculator.rs:26:32

note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
```

For example for `Asia/Almaty` (located in Kazakhstan) `offset_from_utc_date` returns "+6" rather than "GMT+6".

This leads to an error beacuse Regex in Smartcalc expects offset with `GMT` in string:

https://github.com/erhanbaris/smartcalc/blob/cd39b590aba74e8ca326ba78acea488d0550a3e8/src/json/config.json#L35