### PR TITLE
fix: shortcuts with `Option` key

### DIFF
--- a/src/routes/Settings/lib/controls/ShortcutControl.svelte
+++ b/src/routes/Settings/lib/controls/ShortcutControl.svelte
@@ -51,11 +51,10 @@
                         }
                     } else {
                         if (!modifiers.includes(event.key)) {
-                            if (event.key === " "){
-                                shortcutArray.push("Space");
-                            } else {
-                                shortcutArray.push(event.code.substring(3));
-                            }
+                            const key = event.code.startsWith("Key")
+                                ? event.code.substring(3)
+                                : event.code;
+                            shortcutArray.push(key);
                             updateShortcutPreference(shortcutArray);
                             hotkeys.unbind();
                         } else {

--- a/src/routes/Settings/lib/controls/ShortcutControl.svelte
+++ b/src/routes/Settings/lib/controls/ShortcutControl.svelte
@@ -35,8 +35,6 @@
     async function recordShortcut() {
         shortcutArray = [];
         hotkeys.unbind();
-        // Prevent closing Preferences when recording already registered shortcut
-        unregister(preferences.get("shortcut"));
         hotkeys("*", { keyup: true }, function (event) {
             if (event.type === "keydown") {
                 if (shortcutArray.length < 3) {

--- a/src/routes/Settings/lib/controls/ShortcutControl.svelte
+++ b/src/routes/Settings/lib/controls/ShortcutControl.svelte
@@ -35,6 +35,8 @@
     async function recordShortcut() {
         shortcutArray = [];
         hotkeys.unbind();
+        // Prevent closing Preferences when recording already registered shortcut
+        unregister(preferences.get("shortcut"));
         hotkeys("*", { keyup: true }, function (event) {
             if (event.type === "keydown") {
                 if (shortcutArray.length < 3) {
@@ -52,7 +54,7 @@
                             if (event.key === " "){
                                 shortcutArray.push("Space");
                             } else {
-                                shortcutArray.push(event.key);
+                                shortcutArray.push(event.code.substring(3));
                             }
                             updateShortcutPreference(shortcutArray);
                             hotkeys.unbind();


### PR DESCRIPTION
Related to #11.

`event.key` returns transformed char when `option` key is pressed.

For example, when user is trying to record shortcut `Option+Shift+G`, `event.key` returns `Option+Shift+˝`.

`event.code` returns `KeyG` instead. So getting substring with offset 3 fixes this issue.

This commit fixes another bug: when user records shortcut that already registered, window will hide. Adding `unregister` before start recording fixes this issue.